### PR TITLE
fix return type to be same shape as input type

### DIFF
--- a/mapcat/pointing/poly.py
+++ b/mapcat/pointing/poly.py
@@ -182,6 +182,12 @@ class PolynomialPointingModel(PointingModelProtocol):
         racoeffs, deccoeffs = self.extract_coefficients()
         ra_offset = self.model_fn(pos.ra, pos.dec, racoeffs)
         dec_offset = self.model_fn(pos.ra, pos.dec, deccoeffs)
+        if pos.isscalar:
+            # model_fn always returns at-least-1d arrays (see np.atleast_1d
+            # above); squeeze back down so a scalar input yields a scalar
+            # SkyCoord rather than silently promoting it to shape (1,).
+            ra_offset = ra_offset[0]
+            dec_offset = dec_offset[0]
         ra = pos.ra - ra_offset
         dec = pos.dec - dec_offset
 

--- a/tests/test_pointing.py
+++ b/tests/test_pointing.py
@@ -81,6 +81,10 @@ def test_make_polynomial_pointing_model():
 
     for i, offset_pos in enumerate(offset_positions):
         predicted_pos = model.predict(offset_pos)
+        assert predicted_pos.isscalar, (
+            "predict() on a scalar SkyCoord must return a scalar SkyCoord, "
+            f"got shape {predicted_pos.ra.shape}"
+        )
         assert np.isclose(
             predicted_pos.ra.to_value(u.arcmin), ras[i].to_value(u.arcmin), atol=0.1
         )
@@ -89,6 +93,7 @@ def test_make_polynomial_pointing_model():
         )
 
     predicted_pos = model.predict(offset_positions)
+    assert not predicted_pos.isscalar
     assert np.all(
         np.isclose(
             predicted_pos.ra.to_value(u.arcmin), ras.to_value(u.arcmin), atol=0.1


### PR DESCRIPTION
there's an np.atleast_1d that converts to an array, but downstream (i.e. in sotrplib) we assume ra, dec are scalar. so do that here